### PR TITLE
Fix default port 443 addtion

### DIFF
--- a/client.go
+++ b/client.go
@@ -142,7 +142,7 @@ func (c *Client) FetchTLSCert() (*x509.Certificate, error) {
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: true,
 	}
-	conn, err := tls.Dial("tcp", c.gatewayAddress+":443", tlsConfig)
+	conn, err := tls.Dial("tcp", c.gatewayAddress, tlsConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -142,7 +142,7 @@ func (c *Client) FetchTLSCert() (*x509.Certificate, error) {
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: true,
 	}
-	conn, err := tls.Dial("tcp", c.gatewayAddress, tlsConfig)
+	conn, err := tls.Dial("tcp", DefaultPort(c.gatewayAddress, 443), tlsConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/util_net.go
+++ b/util_net.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"net"
+	"strconv"
+)
+
+// DefaultPort appends given port to connection if not specified
+func DefaultPort(conn string, port int) string {
+	if _, _, err := net.SplitHostPort(conn); err != nil {
+		conn = net.JoinHostPort(conn, strconv.Itoa(port))
+	}
+
+	return conn
+}


### PR DESCRIPTION
I ran into the case where I had to portforward the tesla powerwall and couldn't define my own port for evcc. I took the evcc utils approach and added it here. would be great to see that merged and updated in the evcc go.mod

Thanks! 

Disclaimer, I edited this in the browser so it could be that there is the need for go fmt...)